### PR TITLE
small fixes for qtlmap dsl2

### DIFF
--- a/bin/run_susie.R
+++ b/bin/run_susie.R
@@ -357,7 +357,8 @@ if(nrow(cs_df) > 0){
 
 #Extract information about all variants
 if(nrow(variant_df) > 0){
-variant_df <- dplyr::transmute(variant_df, molecular_trait_id = phenotype_id, variant = variant_id, chromosome = chr, position = pos, ref, alt, cs_id, cs_index, low_purity, finemapped_region, pip, z, posterior_mean, posterior_sd, alpha1:sd10)
+  variant_df_transmute <- dplyr::transmute(variant_df, molecular_trait_id = phenotype_id, variant = variant_id, chromosome = chr, position = pos, ref, alt, cs_id, cs_index, low_purity, finemapped_region, pip, z, posterior_mean, posterior_sd)  
+  variant_df <- dplyr::bind_cols(variant_df_transmute, dplyr::select(variant_df,alpha1:sd10))
 }
 
 #Export high purity credible set results only

--- a/conf/eqtl_catalogue.config
+++ b/conf/eqtl_catalogue.config
@@ -12,5 +12,6 @@ params {
   n_batches = 400
   mincisvariant = 5
   n_permutations = 1000
+  run_susie = true
   varid_rsid_map_file = "/gpfs/hpc/projects/genomic_references/annotations/eQTLCatalogue/v0.1/dbSNP_b151_GRCh38p7_splitted_var_rsid.vcf.gz"
 }

--- a/modules/prepare_molecular_traits.nf
+++ b/modules/prepare_molecular_traits.nf
@@ -66,8 +66,8 @@ process make_pca_covariates {
 
     script:
     """
-    plink2 --vcf $vcf --vcf-half-call h --indep-pairwise 50000 200 0.05 --out ${qtl_subset}_pruned_variants --threads ${task.cpus} --memory ${task.memory.mega}
-    plink2 --vcf $vcf --vcf-half-call h --extract ${qtl_subset}_pruned_variants.prune.in --make-bed --out ${qtl_subset}_pruned
+    plink2 --vcf $vcf --vcf-half-call h --indep-pairwise 50000 200 0.05 --out ${qtl_subset}_pruned_variants --threads ${task.cpus} --memory ${task.memory.mega} --const-fid 
+    plink2 --vcf $vcf --vcf-half-call h --extract ${qtl_subset}_pruned_variants.prune.in --make-bed --out ${qtl_subset}_pruned --const-fid 
     plink2 -bfile ${qtl_subset}_pruned --pca ${params.n_geno_pcs} header tabs
     cat plink.eigenvec \\
         | sed '1s/IID/genotype_id/' \\


### PR DESCRIPTION
- made a workaround for weird behaviour of dplyr::transmute
- set run_susie flag to true for eqtl_catalogue project configuration 
- added a flag to plink2 in make_pca_covariates so that it does not account for family id if there are several underscores in vcf genotype_ids